### PR TITLE
Wait until beacon removed

### DIFF
--- a/radbeacon-flasher
+++ b/radbeacon-flasher
@@ -219,11 +219,13 @@ trap(:INT) do
   exit 0
 end
 
-begin
+loop do
   if options.watch
     print "Please insert beacon (ctrl-c to cancel)  "
     wait_for_beacon(options.port)
   end
 
  run(options)
-end while options.watch
+
+ break unless options.watch
+end

--- a/radbeacon-flasher
+++ b/radbeacon-flasher
@@ -174,6 +174,15 @@ end.parse!
   end
 end
 
+def wait_for_remove_beacon(port)
+  loop do
+    # TODO: Refactor so we are not duplicating this util specific code
+    break unless `dfu-util -l`.include?("Found DFU: [2458:fffe]")
+    sleep 0.1
+  end
+  puts
+end
+
 def wait_for_beacon(port)
   loop do
     break if File.exist?(port)
@@ -245,4 +254,6 @@ loop do
  run(options)
 
  break unless options.watch
+
+ wait_for_remove_beacon options.port
 end

--- a/radbeacon-flasher
+++ b/radbeacon-flasher
@@ -183,17 +183,29 @@ def wait_for_beacon(port)
   puts
 end
 
-def notify_start
-  if File.exist? "/System/Library/Sounds/Purr.aiff"
-    `afplay /System/Library/Sounds/Purr.aiff`
-  end
+require 'pathname'
+START_SOUND   = Pathname("/System/Library/Sounds/Purr.aiff")
+SUCCESS_SOUND = Pathname("/System/Library/Sounds/Frog.aiff")
+FAILURE_SOUND = Pathname("/System/Library/Sounds/Sosumi.aiff")
+
+def play_sound(file)
+  `afplay #{file}`
 end
+
+def notify_start
+  play_sound START_SOUND if START_SOUND.exist?
+end
+
 def notify_success
-  if File.exist? "/System/Library/Sounds/Frog.aiff"
-    `afplay /System/Library/Sounds/Frog.aiff`
-  end
+  play_sound SUCCESS_SOUND if SUCCESS_SOUND.exist?
   puts
   puts "Success!"
+end
+
+def notify_failure
+  play_sound FAILURE_SOUND if FAILURE_SOUND.exist?
+  puts
+  puts "Failure!"
 end
 
 def run(options)
@@ -208,8 +220,13 @@ def run(options)
   if (dfu.apply)
     puts "DFU Success, flashing..."
     flasher = Flasher.new(file.path)
-    notify_success if flasher.flash
+    if flasher.flash
+      notify_success
+    else
+      notify_failure
+    end
   else
+    notify_failure
     STDERR.puts "ERROR: DFU failed!"
   end
 end

--- a/radbeacon-flasher
+++ b/radbeacon-flasher
@@ -214,6 +214,11 @@ def run(options)
   end
 end
 
+trap(:INT) do
+  puts "\n\n    kthxbye"
+  exit 0
+end
+
 begin
   if options.watch
     print "Please insert beacon (ctrl-c to cancel)  "
@@ -221,9 +226,4 @@ begin
   end
 
  run(options)
-
-rescue Interrupt
-  puts "\n\n    kthxbye"
-  exit 0
 end while options.watch
-


### PR DESCRIPTION
This performs some minor refactoring clean up around the current run loop. It also adds a wait after the flashing process. The process will now wait until the beacon is removed before re-starting the loop.

This helps people who get distracted or may have missed hearing the tone notifying the end of the flashing process. Without this wait, when the person checks the output, there is no way for them to know if what they are seeing is for the beacon plugged in or the previous beacon.

/cc @csexton @davemradnet 