### PR TITLE
Check file and flash DFU

### DIFF
--- a/radbeacon-flasher
+++ b/radbeacon-flasher
@@ -43,11 +43,9 @@ require 'net/http'
 class FirmwareError < StandardError; end
 
 class FirmwareFile
+  DEFAULT_PREFIX = "radbeacon-usb-"
   SIZE=124928
 
-  def initialize(version)
-    version = mangle_version(version)
-  DEFAULT_PREFIX = "radbeacon-usb-"
   def initialize(firmware_name)
     firmware_name = mangle_name(firmware_name)
 


### PR DESCRIPTION
Checks to see if firmware file is of the correct size, this will help to prevent flashing incompatible firmware files which could corrupt the device

Also, will continue flashing if the dongle was stuck in DFU mode. Previously, using the `-w` option, if a dongle that was already in DFU mode was inserted, it would not be flashed. However, it is safe (and probably desirable) to flash dongles that are in DFU mode.