### PR TITLE
Update default firmware version to 3.2.4

### DIFF
--- a/radbeacon-flasher
+++ b/radbeacon-flasher
@@ -31,7 +31,7 @@ require "uri"
 # Default Settings
 #
 options = OpenStruct.new
-options.version = "3.2.3"
+options.version = "3.2.4"
 options.watch = false
 options.port = "/dev/tty.usbmodem1"
 


### PR DESCRIPTION
Merge after the RadBeacon USB v3.2.4 has been vetted.
